### PR TITLE
added docker-compose

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,25 @@
+# Node.js dependencies
+node_modules
+npm-debug.log
+
+# Logs
+logs
+*.log
+
+# Temporary files
+tmp
+temp
+
+# Build output
+dist
+build
+
+
+# Git
+.git
+.gitignore
+
+# IDE files
+.vscode
+.idea
+*.swp

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20
+
+WORKDIR /app/backend
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 3000
+CMD ["npm", "run", "dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  backend:
+    build: ./backend
+    container_name: backend
+    environment:
+      - MONGO_DB_URL=mongodb://mongo:27017/todos
+    ports:
+      - "3000:3000"
+    depends_on:
+      - mongo
+    volumes:
+      - ./backend:/app/backend
+    command: npm run dev
+
+  frontend:
+    build: ./frontend
+    container_name: frontend
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./frontend:/app/frontend
+    command: npm run dev
+
+  mongo:
+    image: mongo:latest
+    container_name: mongo
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
+
+volumes:
+  mongo-data:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,24 @@
+# Node.js dependencies
+node_modules
+npm-debug.log
+
+# Logs
+logs
+*.log
+
+# Temporary files
+tmp
+temp
+
+# Build output
+dist
+build
+
+# Git
+.git
+.gitignore
+
+# IDE files
+.vscode
+.idea
+*.swp

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-alpine
+
+WORKDIR /app/frontend
+
+COPY package* .
+RUN npm install
+
+COPY . .
+
+EXPOSE 8080
+CMD ["npm", "run", "dev"]


### PR DESCRIPTION
## Add docker compose

### Description
This PR adds Docker support for both the backend and frontend services. It includes Dockerfiles for each service and a `docker-compose.yml` file to orchestrate the services.

### Changes
- Added `Dockerfile` for the backend service in `backend/Dockerfile`.
- Added `Dockerfile` for the frontend service in `frontend/Dockerfile`.
- Added `docker-compose.yml` to manage multi-container Docker applications.

### Command to Run
```bash
docker-compose up --build
```
you can update it readme as well

ps: close this pr  with “hacktoberfest-accepted” label.